### PR TITLE
Adds function for executing bash commands

### DIFF
--- a/BriskScript/Sources/Brisk/System.swift
+++ b/BriskScript/Sources/Brisk/System.swift
@@ -37,3 +37,23 @@ func open(_ thing: String) {
     NSWorkspace.shared.openFile(thing)
 }
 #endif
+
+/// Executes a bash command as is and returns the output
+/// This is using `/usr/bin/env bash` (bash-5.0) since `/bin/bash` refers to older bash-3.2 on OSX
+/// - Parameters:
+///   - command: bash command as it would be typed in terminal. e.g. `ls -lah`
+/// - Returns: `String` console output
+func bash(_ command: String) -> String {
+    let task = Process()
+    let pipe = Pipe()
+
+    task.standardOutput = pipe
+    task.arguments = ["bash", "-c", command]
+    task.launchPath = "/usr/bin/env"
+    task.launch()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8)!
+
+    return output
+}


### PR DESCRIPTION
## contribute to twostraws/brisk

Hi @twostraws, 

this package looks great and easy to use. Thanks for sharing! 

Please correct me if it's already there and I just didn't see it, but I thought a method for executing shell commands via `bash` might be helpful.   
E.g. for using command line build tools.  
My use-case would be running a build script for xcframeworks with it.

Please have a look at the Commit. 
The callsite looks like:

```swift
let output = bash("cal 9 1752")
print(output)
/*
   September 1752     
Su Mo Tu We Th Fr Sa  
       1  2 14 15 16  
17 18 19 20 21 22 23  
24 25 26 27 28 29 30  
*/
```

It's essentially taken from here: https://stackoverflow.com/a/50035059/2064473 with some modifications for using `bash-5.0` instead of the default `bash-3.2` on OSX.  

I did put it into the `System.swift` since I didn't think it warrants a new file at this point.

Let me know what you think.  

Cheers,
Martin

I was pondering doing it as a `shell()` method and opening up the `launchPath` as a parameter, but that would have added some (mostly) unnecessary complexity, considering how to designed the rest of Brisk.